### PR TITLE
Replace ugettext_lazy which is deprecated

### DIFF
--- a/django_iban/fields.py
+++ b/django_iban/fields.py
@@ -1,5 +1,5 @@
 from django.db.models         import CharField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_iban.utils         import clean_iban
 from django_iban.forms         import IBANFormField


### PR DESCRIPTION
django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().